### PR TITLE
Query in `getModelsPerType()` only by ids

### DIFF
--- a/src/Searcher.php
+++ b/src/Searcher.php
@@ -518,7 +518,7 @@ class Searcher
                 $ids = $results->pluck($key)->filter();
 
                 return $ids->isNotEmpty()
-                    ? $modelToSearchThrough->getFreshBuilder()->whereKey($ids)->get()->keyBy->getKey()
+                    ? $modelToSearchThrough->getModel()->newQueryWithoutScopes()->whereKey($ids)->get()->keyBy->getKey()
                     : null;
             });
 


### PR DESCRIPTION
There is no need to use other query conditions (e.g. local and global scopes) here again, because they are already present in the query in the "getIdAndOrderAttributes()"-method. So, it's sufficient enough to load the models by id.

I've recently posted that pull request at [protonemedia/laravel-cross-eloquent-search](https://github.com/protonemedia/laravel-cross-eloquent-search/pull/81/commits/014a716860566d51c2066e09c305457319aa65b3), but that one is closed because I had to delete the forked head repository, to switch to a fork of your fork [artkonekt/search](https://github.com/artkonekt/search). 